### PR TITLE
fix(tmdb): filter unknown TMDB JSON fields before constructing Movie/TvShow

### DIFF
--- a/services/tmdb.py
+++ b/services/tmdb.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from dataclasses import fields
 from typing import TypeVar
 import aiohttp
 
@@ -17,6 +18,18 @@ settings = get_settings()
 BASE_URL = "https://api.themoviedb.org/3"
 TMDB_APIKEY = settings.tracker.TMDB_APIKEY
 T = TypeVar('T')
+
+# TMDB occasionally adds new fields to its responses (e.g. `softcore`). The
+# local dataclasses don't declare them, so passing the raw payload via
+# `Movie(**item)` blows up with TypeError. Filter to known fields before
+# instantiation so the upstream payload doesn't break the parser.
+_MOVIE_FIELDS = {f.name for f in fields(Movie)}
+_TV_FIELDS = {f.name for f in fields(TvShow)}
+
+
+def _only_known(item: dict, allowed: set[str]) -> dict:
+    """Return a copy of ``item`` with only the keys present in ``allowed``."""
+    return {k: v for k, v in item.items() if k in allowed}
 
 
 # Endpoints TMDB
@@ -99,10 +112,10 @@ class TmdbAsyncAPI:
             items = data["results"]
             if category == "movie":
                 for item in items:
-                    results.append(Movie(**item))  # converte JSON in dataclass Movie
+                    results.append(Movie(**_only_known(item, _MOVIE_FIELDS)))
             else:  # "tv"
                 for item in items:
-                    results.append(TvShow(**item))  # converte JSON in dataclass TvShow
+                    results.append(TvShow(**_only_known(item, _TV_FIELDS)))
 
         return results
 


### PR DESCRIPTION
## Sommario

Fixa #1: il campo `softcore` (recentemente aggiunto da TMDB ai risultati di `/search/movie`) faceva esplodere `Movie(**item)` con `TypeError`, lasciando `/scan` con risultati vuoti.

## Cosa cambia

- `services/tmdb.py`: filtra il dict in arrivo da TMDB ai soli campi dichiarati nelle dataclass `Movie` / `TvShow` prima di costruirle, usando `dataclasses.fields()`. È un fix idempotente e forward-compatible: qualsiasi futuro campo nuovo aggiunto da TMDB non rompe più il parser.

## Test plan

- [x] Riprodotto il bug con un film recente (TMDB ritorna `softcore` per quasi tutti i risultati ora). Prima del fix: `[ERROR] ScanMediaUseCase: ... Movie.__init__() got an unexpected keyword argument 'softcore'` + `/scan` ritorna `{"results": []}`.
- [x] Dopo il fix: `/scan` completa, log mostra `[OK] Uploaded https://img2.ptscreens.com/...`, `Process media -> ...`, `Scan completato in 6.14 secondi`. Il poster appare correttamente nel frontend.
- [x] Pipeline completa testata: `/scan → /maketorrent → /upload → /seed` tutti 200, torrent caricato sul tracker.

## Riferimenti

- Issue: #1
