### PR TITLE
fix(media): pick highest standard resolution that fits video_height

### DIFF
--- a/unit3dwup/models/media.py
+++ b/unit3dwup/models/media.py
@@ -497,10 +497,23 @@ class Media:
     def resolution(self) -> str | None:
         if not self._resolution:
             if self.mediafile and self.mediafile.video_height:
-                closest_resolution = min(
-                    System.RESOLUTIONS,
-                    key=lambda x: abs(int(x) - int(self.mediafile.video_height))
+                # Pick the highest standard resolution whose height fits the
+                # video. The previous `min(abs())` heuristic mis-classified
+                # 1080p widescreen content as 720p (a 1080p movie in 2.39:1
+                # has a video_height of ~800, which is closer to 720 than to
+                # 1080). A 50px tolerance rounds up when the height is just
+                # below a step (cropped masters, encoder padding).
+                tolerance = 50
+                ladder = sorted(
+                    (int(r) for r in System.RESOLUTIONS), reverse=True
                 )
+                height = int(self.mediafile.video_height)
+                chosen = ladder[-1]
+                for step in ladder:
+                    if height >= step - tolerance:
+                        chosen = step
+                        break
+                closest_resolution = str(chosen)
                 scan_type = self.mediafile.video_scan_type
                 if scan_type:
                     closest_resolution = f"{closest_resolution}p" if scan_type.lower() == "progressive" else f"{closest_resolution}i"


### PR DESCRIPTION
## Sommario

Fixa #2: i film 1080p in formato widescreen (2.39:1, 2.35:1, ecc.) venivano caricati sul tracker come 720p perché l'algoritmo `min(abs())` sceglie la risoluzione più vicina al `video_height`, che in 2.39:1 vale ~800 px (più vicino a 720 che a 1080).

## Cosa cambia

- `models/media.py::resolution`: invece di `min(abs(step − height))`, percorre la ladder di risoluzioni standard dall'alto verso il basso e sceglie la prima il cui step è ≤ `height + tolleranza` (50px). Così:
  - height 800 (1080p in 2.39:1) → 1080 ✓
  - height 1080 (1080p flat) → 1080 ✓
  - height 1600 (2160p in 2.39:1) → 2160 ✓
  - height 720 (720p flat) → 720 ✓

## Test plan

- [x] Caso reale (file `1080p H.265 2.39:1`): prima del fix il torrent veniva caricato come 720p; dopo il fix risulterebbe correttamente 1080p (verifica via tracker).
- [x] Logica testata mentalmente sui valori `[8640, 4320, 2160, 1080, 720, 576, 480]` con varie altezze (800, 1080, 1440, 1600, 2160, 2400). Tutti scelgono il gradino atteso.

## Note

La tolleranza di 50px copre encoder padding e cropping minore. Se un master ha height molto inferiore alla risoluzione dichiarata (es. 1080p ridotto a 540p reali), il fix sceglie comunque il gradino sotto, comportamento conservativo corretto.

## Riferimenti

- Issue: #2
