### PR TITLE
fix(upload): support season packs and propagate tracker rejections

### DIFF
--- a/unit3dwup/services/auto_async_service.py
+++ b/unit3dwup/services/auto_async_service.py
@@ -226,6 +226,10 @@ class AsyncMediaManager:
         media.display_name = ManageTitles.clean_text(Path(media.torrent_path).name)
         media.torrent_name = Path(media.torrent_path).name
         media.doc_description = "\n".join(files)
+        # A folder with multiple video files is a season pack: trackers (Unit3D)
+        # require episode_number=0 in this case, and the title builder skips
+        # the per-episode suffix.
+        media.torrent_pack = len(files) > 1
 
         entries = await asyncio.to_thread(lambda: list(self.scan_folder(media.torrent_path)))
         sizes = [e.stat().st_size for e in entries]

--- a/unit3dwup/services/itt_tracker_service.py
+++ b/unit3dwup/services/itt_tracker_service.py
@@ -35,6 +35,16 @@ class ITTtrackerService(TrackerServiceInterface):
         The Media object processed helps to build the payload for the tracker
         """
         settings = get_settings()
+        # Unit3D requires `season_number` and `episode_number` to be integers.
+        # For season packs (a folder containing multiple episodes) the
+        # convention is `episode_number=0`. Sending an empty string makes
+        # Unit3D respond with `{'episode_number': ['... required.']}` and
+        # silently drops the upload.
+        season_number = int(media.guess_season) if media.guess_season else 0
+        if media.torrent_pack:
+            episode_number = 0
+        else:
+            episode_number = int(media.guess_episode) if media.guess_episode else 0
         return {
             "name": media.display_name,
             "tmdb": media.tmdb_id or 0,
@@ -48,8 +58,8 @@ class ITTtrackerService(TrackerServiceInterface):
             "description": media.description,
             "sd": media.is_hd,
             "type_id": self.tracker_data.filter_type(media.file_name),
-            "season_number": media.guess_season or "",
-            "episode_number": media.guess_episode or "",
+            "season_number": season_number,
+            "episode_number": episode_number,
             "personal_release": int(settings.prefs.PERSONAL_RELEASE)
         }
 

--- a/unit3dwup/use_case/upload_usecase.py
+++ b/unit3dwup/use_case/upload_usecase.py
@@ -57,12 +57,8 @@ class UploadUseCase:
             # Send a message to frontend for each uploaded media
             await self.broadcast_messages(uploaded_torrents=uploaded_torrents)
 
-            for torrent in uploaded_torrents:
-                await self.app.state.ws_manager.broadcast({
-                    "type": "posterLogMessage",
-                    "job_id": torrent['job_id'],
-                    "message": f"{torrent['message']}"})
-        return True
+        # Overall execution outcome: True iff every torrent reported HTTP 200.
+        return all(_is_successful(t) for t in uploaded_torrents)
 
     async def broadcast_messages(self, uploaded_torrents: tuple[Any]) -> None:
         """
@@ -73,4 +69,15 @@ class UploadUseCase:
             await self.app.state.ws_manager.broadcast({
                 "type": "posterLogMessage",
                 "job_id": torrent['job_id'],
+                # Distinguish success from failure so the frontend can colour
+                # the poster correctly and clients listening on /ws can react
+                # to an error without having to parse `message` heuristically.
+                "level": "success" if _is_successful(torrent) else "error",
                 "message": f"{torrent['message']}"})
+
+
+def _is_successful(torrent: dict) -> bool:
+    """A torrent dict from `ITTtrackerService.upload` reports `status: '200'`
+    on success and `'404'` / `'409'` (or other non-2xx) on failure."""
+    status = str(torrent.get('status') or '')
+    return status.startswith('2')


### PR DESCRIPTION
## Sommario

Fixa #5: i season pack (cartella con più episodi) non vengono caricati sul tracker, Unit3D risponde `400 Bad Request` con `{'episode_number': ['The episode number field is required.']}` ma webup ritorna `200 OK` al chiamante e seeda comunque il `.torrent` localmente, dando l'impressione di un upload riuscito.

## Tre fix correlati

1. **`services/auto_async_service.py::process_folder`**: quando una cartella ha più di un file video, ora setta `media.torrent_pack = True`. Prima il setter non veniva mai invocato (cercando `torrent_pack` nel codebase il setter risulta morto), quindi `generate_title` (che già rispetta il flag a riga 228) e il payload del tracker non sapevano mai di star processando un pack.

2. **`services/itt_tracker_service.py::prepare_payload`**: `season_number` e `episode_number` ora sono garantiti essere `int`. Per i pack, `episode_number=0` (convenzione Unit3D). Prima venivano inviati `""` quando `guessit` non aveva trovato il numero, e Unit3D rifiuta valori non interi.

3. **`use_case/upload_usecase.py::execute`**: il `posterLogMessage` ora include `level: success|error` derivato dallo `status` del response del tracker. `execute()` ritorna `True` solo se TUTTI i torrent hanno status `2xx`, non incondizionatamente.

## Test plan

- [x] Reprodotto il bug con una cartella `1899 S01 1080p .../` con 8 episodi.
  - Prima: `POST /upload` → 200 OK; tracker logga `{'episode_number': ['... required.']}` due volte; il torrent appare seedato ma non sul tracker.
  - Dopo (atteso): payload corretto con `episode_number=0` per pack, response del tracker 200, torrent visibile sul tracker.
- [x] Verificato che il flag `torrent_pack` arriva alle pipeline a valle (`generate_title` lo usa già a riga 228 di `models/media.py`).
- [x] `posterLogMessage` ora ha `level: error` quando il tracker rifiuta, i client che fanno parsing dei livelli (es. wrapper esterni) possono finalmente distinguere successo/errore senza ispezionare il `message`.

## Note

- Il fix non tocca altri tracker (per ora c'è solo ITT). La conversione `int(...) if ... else 0` è generica e va bene per qualsiasi tracker Unit3D.
- I file `chmod 755` sul fork erano stati persi da un edit di IDE; ripristinati.

## Riferimenti

- Issue: #5
