### PR TITLE
fix(qbit): apply configured TORRENT__TAG to torrents added to qBittorrent

### DIFF
--- a/unit3dwup/services/torrent_client_service.py
+++ b/unit3dwup/services/torrent_client_service.py
@@ -67,6 +67,11 @@ class QbittorrentClientService(TorrentClientServiceInterface):
         if not self.qbt_client or not self.qbt_client.is_logged_in:
             await self.login()
 
+        # Apply the configured tag (TORRENT__TAG) so users can find their bot
+        # uploads in qBittorrent's "Tags" sidebar. qbittorrentapi creates the
+        # tag automatically if it doesn't exist yet.
+        tag = (settings.torrent.TAG or "").strip() or None
+
         try:
             await asyncio.to_thread(
             self.qbt_client.torrents_add,
@@ -74,7 +79,8 @@ class QbittorrentClientService(TorrentClientServiceInterface):
             save_path=save_path, # Host
             autoTMM=False,
             paused=False,
-            is_skip_checking=True
+            is_skip_checking=True,
+            tags=tag,
             )
         except qbittorrentapi.exceptions.TorrentFileError as e:
             logging.info(f"Add torrents {e}")


### PR DESCRIPTION
## Sommario

Fixa #8: la chiave `TORRENT__TAG` non veniva applicata ai torrent aggiunti a qBittorrent.

## Cosa cambia

- `services/torrent_client_service.py::add_torrents`: passa `tags=settings.torrent.TAG` (stripped, `None` se vuoto) a `qbt_client.torrents_add`. qbittorrentapi crea automaticamente il tag su qBittorrent se non esiste.

## Test plan

- [x] Configurato `.env` con `TORRENT__TAG=Unit3DupBot-DEV`, eseguito upload pipeline (`/scan` → `/maketorrent` → `/upload` → `/seed`).
- [x] qBittorrent: torrent presente con tag `Unit3DupBot-DEV` visibile nella sidebar "Tags" e nella colonna del torrent.

## Riferimenti

- Issue: #8
