### PR TITLE
fix: qualifica l'import del limiter in start.py (risolve il crash d'avvio 0.0.27)

### DIFF
--- a/unit3dwup/start.py
+++ b/unit3dwup/start.py
@@ -11,7 +11,7 @@ from unit3dwup.lifespan import lifespan
 from unit3dwup.routers import scan, process, jobs, posters, settings, search, ws
 
 # Set a limiter
-from config.limiter import limiter
+from unit3dwup.config.limiter import limiter
 
 # Initialize FastApi
 app = FastAPI(lifespan=lifespan)


### PR DESCRIPTION
## Cosa

`start.py` importa il limiter di slowapi con un top-level `from config.limiter import limiter`, che fallisce con `ModuleNotFoundError: No module named 'config'` quando il pacchetto e installato via pip ed eseguito come `uvicorn unit3dwup.start:app`. Di conseguenza la 0.0.27 non si avvia per chi installa il pacchetto.

Questa PR qualifica l'import in modo coerente col resto del file e con i router:

```diff
-from config.limiter import limiter
+from unit3dwup.config.limiter import limiter
```

## Perché

`config` e un subpackage di `unit3dwup` (`unit3dwup/config/limiter.py`), non un modulo top-level. Tutti gli altri import in `start.py` usano gia la forma `unit3dwup.*`, e tutti i router importano gia il limiter come `from unit3dwup.config.limiter import limiter`. Solo questa riga era sfuggita, quindi si risolve solo quando `unit3dwup/` e in `sys.path` (esecuzione dall'albero dei sorgenti), non per una normale installazione pip.

## Come verificare

```bash
# 0.0.27 cosi com'e, riproduce il bug (nessuna dipendenza necessaria):
python -c "import config.limiter"            # ModuleNotFoundError: No module named 'config'

# il path verso cui punta il fix esiste gia (lo usano i router):
python -c "import unit3dwup.config.limiter"  # ok
```

Fixes #24.
